### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/pages/Scouting.tsx
+++ b/src/components/pages/Scouting.tsx
@@ -12,6 +12,11 @@ import type { StatEvent, StatTeam } from '../../utils/statbotics';
 
 export type SortKey = 'team' | 'epa' | 'epa_auto' | 'epa_teleop' | 'epa_endgame' | 'opr' | 'dpr' | 'ccwm';
 
+// Sanitize event code: allow only alphanumeric and hyphens (typical event code chars)
+function sanitizeEventCode(code: string): string {
+  return code.replace(/[^a-zA-Z0-9-]/g, '');
+}
+
 export default function Scouting() {
   useScrollReveal();
 
@@ -109,8 +114,8 @@ export default function Scouting() {
         start_date: eventInfo.start_date,
         location: [eventInfo.city, eventInfo.state, eventInfo.country].filter(Boolean).join(', '),
         num_teams: eventInfo.team_count ?? teams.length,
-        tba_link: `https://www.thebluealliance.com/event/${eventCode}`,
-        stat_link: `https://statbotics.io/event/${eventCode}`,
+        tba_link: `https://www.thebluealliance.com/event/${sanitizeEventCode(eventCode)}`,
+        stat_link: `https://statbotics.io/event/${sanitizeEventCode(eventCode)}`,
       }} />}
 
       {teams.length > 0 && (


### PR DESCRIPTION
Potential fix for [https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/2](https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/2)

To fix the problem, we should ensure that the event code (user-controlled input) used to construct URLs for anchor tags is validated and sanitized before use. The event code should only allow safe, expected characters (e.g., alphanumeric, possibly hyphens for event codes), and reject or neutralize any input containing characters that could cause the attribute values to be reinterpreted or injected as HTML or affect navigation. 

The best approach is to sanitize the event code both when loading the event and when constructing the URLs for the links. This can be accomplished by introducing a sanitization utility function (e.g., `sanitizeEventCode`) that strips any disallowed characters from the event code. Update both URL constructions for `tba_link` and `stat_link` in `Scouting.tsx` to use this sanitized event code. You can add this function directly to `Scouting.tsx`.

Changes required:
- Add a utility function in `Scouting.tsx` to sanitize event codes.
- Use the sanitized event code to construct the URLs for `tba_link` and `stat_link` in the props for `EventInfoCard`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
