### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/pages/Scouting.tsx
+++ b/src/components/pages/Scouting.tsx
@@ -12,6 +12,11 @@ import type { StatEvent, StatTeam } from '../../utils/statbotics';
 
 export type SortKey = 'team' | 'epa' | 'epa_auto' | 'epa_teleop' | 'epa_endgame' | 'opr' | 'dpr' | 'ccwm';
 
+// Only allow event codes that are alphanumeric, dashes, or underscores
+function sanitizeEventCode(code: string): string {
+  return (code || '').replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
 export default function Scouting() {
   useScrollReveal();
 
@@ -109,8 +114,8 @@ export default function Scouting() {
         start_date: eventInfo.start_date,
         location: [eventInfo.city, eventInfo.state, eventInfo.country].filter(Boolean).join(', '),
         num_teams: eventInfo.team_count ?? teams.length,
-        tba_link: `https://www.thebluealliance.com/event/${eventCode}`,
-        stat_link: `https://statbotics.io/event/${eventCode}`,
+        tba_link: `https://www.thebluealliance.com/event/${sanitizeEventCode(eventCode)}`,
+        stat_link: `https://statbotics.io/event/${sanitizeEventCode(eventCode)}`,
       }} />}
 
       {teams.length > 0 && (


### PR DESCRIPTION
Potential fix for [https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/1](https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/1)

To fix the problem, sanitize the user input (`eventCode`) before interpolating it into the URLs used for anchor `href` attributes. The **best way** is to ensure that only legitimate, expected event codes (alphanumeric, possibly with limited dashes/underscores) are allowed and to reject or sanitize any unexpected characters. This can be done by cleaning the value at the source, but since the issue shows up at the point of constructing URLs for EventInfoCard, the most robust fix is to sanitize the `eventCode` before using it to construct the links in `Scouting.tsx`. 

Specifically:  
- Add a function to sanitize the event code (allowing only certain characters) in `Scouting.tsx`.  
- Use this sanitization function when constructing `tba_link` and `stat_link` in the `<EventInfoCard>` props.  
- Optionally, you could also sanitize at the point you set `eventCode` in the state, but cleaning at the "sink" is direct and minimal.  
- This does not change any existing functionality but ensures URLs can't be manipulated for XSS or malicious redirects.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
