### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/src/utils/frcAPI.ts
+++ b/src/utils/frcAPI.ts
@@ -161,7 +161,10 @@ export class FRCAPIService {
     // Use a stable random session id per install/tab to help rate limiting bucket by session when unauthenticated
     let sessionId = localStorage.getItem('session_id');
     if (!sessionId) {
-      sessionId = Math.random().toString(36).slice(2) + Date.now().toString(36);
+      // Generate a cryptographically secure random string
+      const randomUint8 = window.crypto.getRandomValues(new Uint8Array(16));
+      const randomStr = Array.from(randomUint8).map(b => b.toString(36)).join('');
+      sessionId = randomStr + Date.now().toString(36);
       try { localStorage.setItem('session_id', sessionId); } catch {}
     }
     const headers: HeadersInit = {


### PR DESCRIPTION
Potential fix for [https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/3](https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/3)

To fix this issue, replace the use of `Math.random()` in the session ID generation (line 164) with a cryptographically secure random number generator. In the Node.js/browser environment, `window.crypto.getRandomValues()` (in browser) or `require('crypto').randomBytes()` (in Node.js) should be used. Since this code likely runs in a browser (because it uses `localStorage`), we can use `window.crypto.getRandomValues` to generate a random string. We'll generate a Uint8Array of bytes, convert them to a base36 string, and use that instead of the substring of `Math.random()`. No changes to functionality should be made—simply update the session ID generation logic and ensure browser compatibility.

Regions to change:
- In file `src/utils/frcAPI.ts`, replace line 164 to use `window.crypto.getRandomValues` for generating a secure random string.
- No changes outside the code provided—no additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
