### PR TITLE
Potential fix for code scanning alert no. 5: Shell command built from environment values

### DIFF
--- a/scripts/androidRelease.mjs
+++ b/scripts/androidRelease.mjs
@@ -31,7 +31,7 @@ function run(cmd, args, opts = {}) {
   let res = spawnSync(cmd, args, { stdio: 'inherit', cwd: root, shell: useShell, ...opts });
   if (res.error) {
     // Fallback: only try via cmd.exe /c for .cmd/.bat (NOT arbitrary paths like process.execPath)
-    if (isWin && /\.(cmd|bat)$/i.test(cmd)) {
+    if (isWin && /\.(cmd|bat)$/i.test(cmd) && !path.isAbsolute(cmd)) {
       console.log(`↺ Retry via cmd.exe /c ${cmd}`);
       res = spawnSync('cmd.exe', ['/c', cmd, ...args], { stdio: 'inherit', cwd: root, shell: false, ...opts });
     } else if (isWin) {


### PR DESCRIPTION
Potential fix for [https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/5](https://github.com/Avexel-Web-Design/FRC7790.com/security/code-scanning/5)

To address this issue, we need to ensure that executing shell commands using absolute paths (such as `process.execPath`) never unintentionally routes through the fallback that invokes `cmd.exe /c` with `cmd` and `args` constructed from unknown paths. The fallback logic in the `run` function should only allow `.cmd` or `.bat` files (as originally intended) to be retried via `cmd.exe /c`, and **never** retry arbitrary absolute paths like node executables in this way.

This can be achieved by tightening the conditional so that only commands ending with `.cmd` or `.bat` use the `cmd.exe` fallback, and explicitly preventing absolute paths or node/native executables from entering this path. We'll add a guard check for absolute paths and disallow fallback for such cases. For additional security, we can use Node's `path.isAbsolute` method for robust checking.

The affected region is the fallback logic at line 34–36 inside the `run` function in `scripts/androidRelease.mjs`. Change the conditional at line 34 to ensure it only triggers for `.cmd` or `.bat` files and not for absolute paths.

No extra dependencies are needed—just Node built-in modules, as already used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
